### PR TITLE
Fix eslint rules and testing scripts

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -1,4 +1,11 @@
 {
+  "root": true,
+  "rules": {
+    "newline-before-return": ["error"],
+    "newline-after-var": ["error", "always"],
+    "comma-dangle": ["error", "never"],
+    "promise/always-return": 0
+  },
   "extends": [
     "plugin:shopify/esnext",
     "plugin:shopify/mocha"

--- a/package.json
+++ b/package.json
@@ -20,10 +20,10 @@
     "mocha": "3.0.2"
   },
   "scripts": {
-    "test": "yarn run lint-allow-warning && mocha --compilers js:babel-register -u tdd test/",
+    "test": "yarn run lint && yarn run mocha",
+    "mocha": "mocha --compilers js:babel-register -u tdd $([ -n \"${CI}\" ] && echo --reporter xunit --reporter-options output=$CIRCLE_TEST_REPORTS/junit/mocha.xml) test/",
     "prepublish": "babel -d lib/ src/",
-    "lint": "eslint --max-warnings 0 -c .eslintrc.json src/ test/",
-    "lint-allow-warning": "eslint -c .eslintrc.json src/ test/"
+    "lint": "eslint --max-warnings 0 -c .eslintrc.json $([ -n \"${CI}\" ] && echo -o $CIRCLE_TEST_REPORTS/junit/eslint.xml -f junit) src/ test/"
   },
   "keywords": [
     "graphql,babel"

--- a/src/get-selections.js
+++ b/src/get-selections.js
@@ -59,10 +59,10 @@ export default function getSelections(selectionSet, parentSelections, spreadsId)
       t.callExpression(
         t.memberExpression(
           t.identifier(parentSelection),
-          addOperation,
+          addOperation
         ),
-        args,
-      ),
+        args
+      )
     ));
   });
 

--- a/src/index.js
+++ b/src/index.js
@@ -15,11 +15,11 @@ const templateElementVisitor = {
         t.callExpression(
           t.memberExpression(
             t.identifier('client'),
-            t.identifier('document'),
+            t.identifier('document')
           ),
-          [],
-        ),
-      )],
+          []
+        )
+      )]
     ));
 
     // Parse the document into a GraphQL AST
@@ -43,7 +43,7 @@ export default function() {
         if (path.node.tag.name === tag) {
           path.traverse(templateElementVisitor, {parentPath: path});
         }
-      },
-    },
+      }
+    }
   };
 }

--- a/src/parse-document.js
+++ b/src/parse-document.js
@@ -20,8 +20,8 @@ export default function parseDocument(document, documentId, parentScope) {
       'const',
       [t.variableDeclarator(
         spreadsId,
-        t.objectExpression([]),
-      )],
+        t.objectExpression([])
+      )]
     ));
   }
 
@@ -38,16 +38,16 @@ export default function parseDocument(document, documentId, parentScope) {
           '=',
           t.memberExpression(
             spreadsId,
-            t.identifier(node.name.value),
+            t.identifier(node.name.value)
           ),
           t.callExpression(
             t.memberExpression(
               documentId,
-              t.identifier('defineFragment'),
+              t.identifier('defineFragment')
             ),
-            args,
-          ),
-        ),
+            args
+          )
+        )
       ));
     },
     OperationDefinition(node) {
@@ -81,11 +81,11 @@ export default function parseDocument(document, documentId, parentScope) {
       babelAstNodes.push(t.callExpression(
         t.memberExpression(
           documentId,
-          t.identifier(operationId),
+          t.identifier(operationId)
         ),
-        args,
+        args
       ));
-    },
+    }
   });
 
   return babelAstNodes;

--- a/src/sort-definitions.js
+++ b/src/sort-definitions.js
@@ -12,7 +12,7 @@ function visitFragment(fragment, fragments, fragmentsHash) {
       FragmentSpread(node) {
         // Visit the corresponding fragment definition
         visitFragment(fragmentsHash[node.name.value], fragments, fragmentsHash);
-      },
+      }
     });
     fragment.visited = true;
     fragment.marked = false;

--- a/test/.eslintrc.json
+++ b/test/.eslintrc.json
@@ -1,5 +1,0 @@
-{
-  "extends": [
-    "plugin:shopify/mocha"
-  ]
-}

--- a/test/get-selections-test.js
+++ b/test/get-selections-test.js
@@ -17,28 +17,28 @@ suite('get-selections-test', () => {
         t.callExpression(
           t.memberExpression(
             t.identifier('root'),
-            t.identifier('add'),
+            t.identifier('add')
           ),
-          [t.stringLiteral('field1')],
-        ),
+          [t.stringLiteral('field1')]
+        )
       ),
       t.expressionStatement(
         t.callExpression(
           t.memberExpression(
             t.identifier('root'),
-            t.identifier('add'),
+            t.identifier('add')
           ),
-          [t.stringLiteral('field2')],
-        ),
+          [t.stringLiteral('field2')]
+        )
       ),
       t.expressionStatement(
         t.callExpression(
           t.memberExpression(
             t.identifier('root'),
-            t.identifier('add'),
+            t.identifier('add')
           ),
-          [t.stringLiteral('field3')],
-        ),
+          [t.stringLiteral('field3')]
+        )
       )];
 
     assert.deepEqual(selections, expectedSelections);
@@ -61,7 +61,7 @@ suite('get-selections-test', () => {
         t.callExpression(
           t.memberExpression(
             t.identifier('root'),
-            t.identifier('add'),
+            t.identifier('add')
           ),
           [
             t.stringLiteral('field1'),
@@ -72,7 +72,7 @@ suite('get-selections-test', () => {
                   t.callExpression(
                     t.memberExpression(
                       t.identifier('field1'),
-                      t.identifier('add'),
+                      t.identifier('add')
                     ),
                     [
                       t.stringLiteral('field2'),
@@ -83,39 +83,39 @@ suite('get-selections-test', () => {
                             t.callExpression(
                               t.memberExpression(
                                 t.identifier('field2'),
-                                t.identifier('add'),
+                                t.identifier('add')
                               ),
-                              [t.stringLiteral('field3')],
-                            ),
+                              [t.stringLiteral('field3')]
+                            )
                           ),
                           t.expressionStatement(
                             t.callExpression(
                               t.memberExpression(
                                 t.identifier('field2'),
-                                t.identifier('add'),
+                                t.identifier('add')
                               ),
-                              [t.stringLiteral('field4')],
-                            ),
-                          ),
-                        ]),
-                      ),
-                    ],
-                  ),
+                              [t.stringLiteral('field4')]
+                            )
+                          )
+                        ])
+                      )
+                    ]
+                  )
                 ),
                 t.expressionStatement(
                   t.callExpression(
                     t.memberExpression(
                       t.identifier('field1'),
-                      t.identifier('add'),
+                      t.identifier('add')
                     ),
-                    [t.stringLiteral('field5')],
-                  ),
-                ),
-              ]),
-            ),
-          ],
-        ),
-      ),
+                    [t.stringLiteral('field5')]
+                  )
+                )
+              ])
+            )
+          ]
+        )
+      )
     ];
 
     assert.deepEqual(selections, expectedSelections);
@@ -134,7 +134,7 @@ suite('get-selections-test', () => {
         t.callExpression(
           t.memberExpression(
             t.identifier('root'),
-            t.identifier('addInlineFragmentOn'),
+            t.identifier('addInlineFragmentOn')
           ),
           [
             t.stringLiteral('Product'),
@@ -145,16 +145,16 @@ suite('get-selections-test', () => {
                   t.callExpression(
                     t.memberExpression(
                       t.identifier('Product'),
-                      t.identifier('add'),
+                      t.identifier('add')
                     ),
-                    [t.stringLiteral('field')],
-                  ),
-                ),
-              ]),
-            ),
-          ],
-        ),
-      ),
+                    [t.stringLiteral('field')]
+                  )
+                )
+              ])
+            )
+          ]
+        )
+      )
     ];
 
     assert.deepEqual(selections, expectedSelections);
@@ -169,13 +169,13 @@ suite('get-selections-test', () => {
         t.callExpression(
           t.memberExpression(
             t.identifier('root'),
-            t.identifier('addFragment'),
+            t.identifier('addFragment')
           ),
           [
-            t.memberExpression(spreadId, t.identifier('spreadName')),
-          ],
-        ),
-      ),
+            t.memberExpression(spreadId, t.identifier('spreadName'))
+          ]
+        )
+      )
     ];
 
     assert.deepEqual(selections, expectedSelections);
@@ -193,7 +193,7 @@ suite('get-selections-test', () => {
         t.callExpression(
           t.memberExpression(
             t.identifier('root'),
-            t.identifier('add'),
+            t.identifier('add')
           ),
           [
             t.stringLiteral('field1'),
@@ -201,8 +201,8 @@ suite('get-selections-test', () => {
               t.objectProperty(t.identifier('alias'), t.stringLiteral('fieldAlias')),
               t.objectProperty(
                 t.identifier('args'),
-                t.objectExpression([t.objectProperty(t.identifier('first'), t.numericLiteral(10))]),
-              ),
+                t.objectExpression([t.objectProperty(t.identifier('first'), t.numericLiteral(10))])
+              )
             ]),
             t.arrowFunctionExpression(
               [t.identifier('field1')],
@@ -211,16 +211,16 @@ suite('get-selections-test', () => {
                   t.callExpression(
                     t.memberExpression(
                       t.identifier('field1'),
-                      t.identifier('add'),
+                      t.identifier('add')
                     ),
-                    [t.stringLiteral('field2')],
-                  ),
-                ),
-              ]),
-            ),
-          ],
-        ),
-      ),
+                    [t.stringLiteral('field2')]
+                  )
+                )
+              ])
+            )
+          ]
+        )
+      )
     ];
 
     assert.deepEqual(selections, expectedSelections);

--- a/test/index.js
+++ b/test/index.js
@@ -1,7 +1,0 @@
-import assert from 'assert';
-
-suite('This will test babel-plugin-graphql-js-client-transform', () => {
-  test('It should do something', () => {
-    assert.ok(true, "It's good");
-  });
-});

--- a/test/parse-document-test.js
+++ b/test/parse-document-test.js
@@ -8,7 +8,7 @@ suite('parse-document-test', () => {
   const parentScope = {
     generateUidIdentifier() {
       return spreadsId;
-    },
+    }
   };
   const documentId = t.identifier('_document');
 
@@ -17,20 +17,20 @@ suite('parse-document-test', () => {
       'const',
       [t.variableDeclarator(
         spreadsId,
-        t.objectExpression([]),
-      )],
+        t.objectExpression([])
+      )]
     ),
     t.expressionStatement(
       t.assignmentExpression(
         '=',
         t.memberExpression(
           spreadsId,
-          t.identifier('productFragment'),
+          t.identifier('productFragment')
         ),
         t.callExpression(
           t.memberExpression(
             documentId,
-            t.identifier('defineFragment'),
+            t.identifier('defineFragment')
           ),
           [
             t.stringLiteral('productFragment'),
@@ -42,24 +42,24 @@ suite('parse-document-test', () => {
                   t.callExpression(
                     t.memberExpression(
                       t.identifier('root'),
-                      t.identifier('add'),
+                      t.identifier('add')
                     ),
-                    [t.stringLiteral('title')],
-                  ),
-                ),
-              ]),
-            ),
-          ],
-        ),
-      ),
-    ),
+                    [t.stringLiteral('title')]
+                  )
+                )
+              ])
+            )
+          ]
+        )
+      )
+    )
   ];
 
   const queryDefinitionNodes = [
     t.callExpression(
       t.memberExpression(
         documentId,
-        t.identifier('addQuery'),
+        t.identifier('addQuery')
       ),
       [
         t.arrowFunctionExpression([t.identifier('root')],
@@ -68,15 +68,15 @@ suite('parse-document-test', () => {
               t.callExpression(
                 t.memberExpression(
                   t.identifier('root'),
-                  t.identifier('add'),
+                  t.identifier('add')
                 ),
-                [t.stringLiteral('field')],
-              ),
-            ),
-          ]),
-        ),
-      ],
-    ),
+                [t.stringLiteral('field')]
+              )
+            )
+          ])
+        )
+      ]
+    )
   ];
 
   test('it can add fragment definitions', () => {
@@ -100,7 +100,7 @@ suite('parse-document-test', () => {
       t.callExpression(
         t.memberExpression(
           documentId,
-          t.identifier('addMutation'),
+          t.identifier('addMutation')
         ),
         [
           t.arrowFunctionExpression(
@@ -110,7 +110,7 @@ suite('parse-document-test', () => {
                 t.callExpression(
                   t.memberExpression(
                     t.identifier('root'),
-                    t.identifier('add'),
+                    t.identifier('add')
                   ),
                   [
                     t.stringLiteral('mutateSomething'),
@@ -123,12 +123,12 @@ suite('parse-document-test', () => {
                             t.objectExpression([
                               t.objectProperty(
                                 t.identifier('token'),
-                                t.stringLiteral('abc'),
-                              ),
-                            ]),
-                          ),
-                        ]),
-                      ),
+                                t.stringLiteral('abc')
+                              )
+                            ])
+                          )
+                        ])
+                      )
                     ]),
                     t.arrowFunctionExpression(
                       [t.identifier('mutateSomething')],
@@ -137,20 +137,20 @@ suite('parse-document-test', () => {
                           t.callExpression(
                             t.memberExpression(
                               t.identifier('mutateSomething'),
-                              t.identifier('add'),
+                              t.identifier('add')
                             ),
-                            [t.stringLiteral('field2')],
-                          ),
-                        ),
-                      ]),
-                    ),
-                  ],
-                ),
-              ),
-            ]),
-          ),
-        ],
-      ),
+                            [t.stringLiteral('field2')]
+                          )
+                        )
+                      ])
+                    )
+                  ]
+                )
+              )
+            ])
+          )
+        ]
+      )
     ];
 
     assert.deepEqual(babelAstNodes, expectedBabelAstNodes);
@@ -163,7 +163,7 @@ suite('parse-document-test', () => {
       t.callExpression(
         t.memberExpression(
           documentId,
-          t.identifier('addQuery'),
+          t.identifier('addQuery')
         ),
         [
           t.stringLiteral('myQuery'),
@@ -173,15 +173,15 @@ suite('parse-document-test', () => {
                 t.callExpression(
                   t.memberExpression(
                     t.identifier('root'),
-                    t.identifier('add'),
+                    t.identifier('add')
                   ),
-                  [t.stringLiteral('field')],
-                ),
-              ),
-            ]),
-          ),
-        ],
-      ),
+                  [t.stringLiteral('field')]
+                )
+              )
+            ])
+          )
+        ]
+      )
     ];
 
     assert.deepEqual(babelAstNodes, expectedBabelAstNodes);
@@ -194,11 +194,11 @@ suite('parse-document-test', () => {
       t.callExpression(
         t.memberExpression(
           documentId,
-          t.identifier('addQuery'),
+          t.identifier('addQuery')
         ),
         [
           t.arrayExpression([
-            t.callExpression(t.identifier('variable'), [t.stringLiteral('id'), t.stringLiteral('ID')]),
+            t.callExpression(t.identifier('variable'), [t.stringLiteral('id'), t.stringLiteral('ID')])
           ]),
           t.arrowFunctionExpression(
             [t.identifier('root')],
@@ -207,7 +207,7 @@ suite('parse-document-test', () => {
                 t.callExpression(
                   t.memberExpression(
                     t.identifier('root'),
-                    t.identifier('add'),
+                    t.identifier('add')
                   ),
                   [
                     t.stringLiteral('node'),
@@ -217,10 +217,10 @@ suite('parse-document-test', () => {
                         t.objectExpression([
                           t.objectProperty(
                             t.identifier('id'),
-                            t.callExpression(t.identifier('variable'), [t.stringLiteral('id')]),
-                          ),
-                        ]),
-                      ),
+                            t.callExpression(t.identifier('variable'), [t.stringLiteral('id')])
+                          )
+                        ])
+                      )
                     ]),
                     t.arrowFunctionExpression(
                       [t.identifier('node')],
@@ -229,20 +229,20 @@ suite('parse-document-test', () => {
                           t.callExpression(
                             t.memberExpression(
                               t.identifier('node'),
-                              t.identifier('add'),
+                              t.identifier('add')
                             ),
-                            [t.stringLiteral('id')],
-                          ),
-                        ),
-                      ]),
-                    ),
-                  ],
-                ),
-              ),
-            ]),
-          ),
-        ],
-      ),
+                            [t.stringLiteral('id')]
+                          )
+                        )
+                      ])
+                    )
+                  ]
+                )
+              )
+            ])
+          )
+        ]
+      )
     ];
 
     assert.deepEqual(babelAstNodes, expectedBabelAstNodes);


### PR DESCRIPTION
Only major changes are in `.eslintrc.json` and `package.json`.
Removed `test/.eslintrc.json` and auto-generated test file `test/index.js`.

Removed *a lot* of commas.