### PR TITLE
[FIX] Remove try-catch

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -30,12 +30,8 @@ const templateElementVisitor = {
 
     statementParentPath.insertBefore(babelAstNodes);
 
-    try {
-      this.parentPath.replaceWith(documentId);
-    } catch (error) {
-      throw Error(error.message);
-    }
-  },
+    this.parentPath.replaceWith(documentId);
+  }
 };
 
 export default function() {


### PR DESCRIPTION
Removing a try-catch block that didn't really do anything.
I'm not too sure if we need to catch any other errors here. I *think* the only error this would throw would be some `babel-type` validation on the node types from the plugin finding the wrong parent node. @minasmart?