### PR TITLE
Let user specify variable names

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,17 +35,16 @@ By default, the plugin will search for the tag `gql`. This value is configurable
 
 ## Usage
 
-Simply tag your raw GraphQL queries and the plugin will transform them. If no arguments are supplied to the tag, the 
-plugin will use `client`, `_enum` and `variable` as the variable/function names for an instance of 
-[Shopify/graphql-js-client](https://github.com/Shopify/graphql-js-client), and the `_enum` and `variable` functions.
+Simply tag your raw GraphQL queries and the plugin will transform them. If no arguments are supplied to the tag, the
+plugin will use `client` as the variable name for an instance of
+[Shopify/graphql-js-client](https://github.com/Shopify/graphql-js-client).
+See [examples](#examples) below for this usage.
 
-If you would like to supply your own variable/function names, use the following syntax:
+If you would like to supply your own variable name, use the following syntax:
 ```js
-gql({client: myClient, _enum: myEnum, variable: myVariable})`query ($first: Int!) {
+gql(myClient)`query {
   shop {
-    products(first: $first, sortKey: TITLE) {
-      ...
-    }
+    name
   }
 }`
 ```
@@ -54,21 +53,16 @@ which will transform to
 ```js
 const _document = myClient.document();
 
-_document.addQuery([myVariable("first", "Int!")], root => {
+_document.addQuery(root => {
   root.add("shop", shop => {
-    shop.add("products", {args: {sortKey: myEnum("TITLE"), first: myVariable("first")}}, products => {
-      ...
-    });
+    shop.add('name');
   });
 })
 ```
-You can specify any combination of variable names (e.g. `gql({client: myClient, variable: myVariable})`) and the plugin
-will use default values for the rest (`client`, `_enum` and `variable`).
-
 
 ## Examples
 
-The following are example usages using the default variable/function names.
+The following are example usages with the default variable name.
 
 #### Example 1
 Convert a simple query.

--- a/src/get-selections.js
+++ b/src/get-selections.js
@@ -2,7 +2,7 @@ import * as t from 'babel-types';
 import parseArg from './parse-arg';
 
 // Returns the body of the block statement representing the selections
-export default function getSelections(selectionSet, parentSelections, spreadsId, enumId = t.identifier('_enum'), variableId = t.identifier('variable')) {
+export default function getSelections(selectionSet, parentSelections, spreadsId, clientId = t.identifier('client')) {
   const selections = [];
 
   // Add each selection onto the parentSelection
@@ -35,7 +35,7 @@ export default function getSelections(selectionSet, parentSelections, spreadsId,
       const graphQLArgs = [];
 
       selection.arguments.forEach((argument) => {
-        graphQLArgs.push(parseArg(argument, enumId, variableId));
+        graphQLArgs.push(parseArg(argument, clientId));
       });
 
       options.push(t.objectProperty(t.identifier('args'), t.objectExpression(graphQLArgs)));
@@ -49,7 +49,7 @@ export default function getSelections(selectionSet, parentSelections, spreadsId,
     // Add any selections on this selection
     if (selection.selectionSet) {
       parentSelections.push(name);
-      args.push(t.arrowFunctionExpression([t.identifier(name)], t.blockStatement(getSelections(selection.selectionSet, parentSelections, spreadsId, enumId, variableId))));
+      args.push(t.arrowFunctionExpression([t.identifier(name)], t.blockStatement(getSelections(selection.selectionSet, parentSelections, spreadsId, clientId))));
       parentSelections.pop();
     }
 

--- a/src/index.js
+++ b/src/index.js
@@ -26,7 +26,7 @@ const templateElementVisitor = {
     const document = parse(path.node.value.raw);
 
     // Convert the GraphQL AST into a list of Babel AST nodes of the query building
-    const babelAstNodes = parseDocument(document, documentId, statementParentPath.scope, this.enumId, this.variableId);
+    const babelAstNodes = parseDocument(document, documentId, statementParentPath.scope, this.clientId);
 
     statementParentPath.insertBefore(babelAstNodes);
 
@@ -40,33 +40,11 @@ export default function() {
       TaggedTemplateExpression(path, state) {
         const tag = state.opts.tag || 'gql';
 
-        // If user doesn't specify variable names, use defaults
+        // If user doesn't specify variable names, use default client variable name
         if (path.node.tag.name === tag) {
-          path.traverse(templateElementVisitor, {
-            parentPath: path,
-            clientId: t.identifier('client'),
-            variableId: t.identifier('variable'),
-            enumId: t.identifier('_enum')
-          });
+          path.traverse(templateElementVisitor, {parentPath: path, clientId: t.identifier('client')});
         } else if (path.node.tag.callee.name === tag) {
-          const variableIds = path.node.tag.arguments[0].properties;
-
-          const clientNode = variableIds.find((identifier) => {
-            return identifier.key.name === 'client';
-          });
-          const clientId = clientNode ? clientNode.value : t.identifier('client');
-
-          const enumNode = variableIds.find((identifier) => {
-            return identifier.key.name === '_enum';
-          });
-          const enumId = enumNode ? enumNode.value : t.identifier('_enum');
-
-          const variableNode = variableIds.find((identifier) => {
-            return identifier.key.name === 'variable';
-          });
-          const variableId = variableNode ? variableNode.value : t.identifier('variable');
-
-          path.traverse(templateElementVisitor, {parentPath: path, clientId, enumId, variableId});
+          path.traverse(templateElementVisitor, {parentPath: path, clientId: path.node.tag.arguments[0]});
         }
       }
     }

--- a/src/parse-arg-value.js
+++ b/src/parse-arg-value.js
@@ -1,10 +1,16 @@
 import * as t from 'babel-types';
 
-export default function parseArgValue(argValue, enumId = t.identifier('_enum')) {
+export default function parseArgValue(argValue, clientId = t.identifier('client')) {
   if (argValue.kind === 'StringValue') {
     return t.stringLiteral(argValue.value);
   } else if (argValue.kind === 'EnumValue') {
-    return t.callExpression(enumId, [t.stringLiteral(argValue.value)]);
+    return t.callExpression(
+      t.memberExpression(
+        clientId,
+        t.identifier('enum')
+      ),
+      [t.stringLiteral(argValue.value)]
+    );
   } else if (argValue.kind === 'IntValue') {
     return t.numericLiteral(parseInt(argValue.value, 10));
   } else if (argValue.kind === 'FloatValue') {

--- a/src/parse-arg.js
+++ b/src/parse-arg.js
@@ -1,20 +1,26 @@
 import * as t from 'babel-types';
 import parseArgValue from './parse-arg-value';
 
-export default function parseArg(arg, enumId = t.identifier('_enum'), variableId = t.identifier('variable')) {
+export default function parseArg(arg, clientId = t.identifier('client')) {
   if (arg.value.value) {
     // Scalar or Enum arg value
-    return t.objectProperty(t.identifier(arg.name.value), parseArgValue(arg.value, enumId));
+    return t.objectProperty(t.identifier(arg.name.value), parseArgValue(arg.value, clientId));
   } else if (arg.value.fields) {
     // Object arg value
     const objectProperties = [];
 
     arg.value.fields.forEach((field) => {
-      objectProperties.push(parseArg(field, enumId, variableId));
+      objectProperties.push(parseArg(field, clientId));
     });
 
     return t.objectProperty(t.identifier(arg.name.value), t.objectExpression(objectProperties));
   } else {
-    return t.objectProperty(t.identifier(arg.name.value), t.callExpression(variableId, [t.stringLiteral(arg.value.name.value)]));
+    return t.objectProperty(t.identifier(arg.name.value), t.callExpression(
+      t.memberExpression(
+        clientId,
+        t.identifier('variable')
+      ),
+      [t.stringLiteral(arg.value.name.value)]
+    ));
   }
 }

--- a/src/parse-document.js
+++ b/src/parse-document.js
@@ -6,7 +6,7 @@ import sortDefinitions from './sort-definitions';
 
 // Goes through the document, parsing each OperationDefinition (i.e. query/mutation) and FragmentDefinition
 // and returns the resulting query builder code
-export default function parseDocument(document, documentId, parentScope, enumId = t.identifier('_enum'), variableId = t.identifier('variable')) {
+export default function parseDocument(document, documentId, parentScope, clientId = t.identifier('client')) {
   const babelAstNodes = [];
   let spreadsId;
 
@@ -31,7 +31,7 @@ export default function parseDocument(document, documentId, parentScope, enumId 
       // Fragments are always named
       const args = [t.stringLiteral(node.name.value), t.stringLiteral(node.typeCondition.name.value)];
 
-      args.push(t.arrowFunctionExpression([t.identifier('root')], t.blockStatement(getSelections(node.selectionSet, parentSelections, spreadsId, enumId, variableId))));
+      args.push(t.arrowFunctionExpression([t.identifier('root')], t.blockStatement(getSelections(node.selectionSet, parentSelections, spreadsId, clientId))));
 
       babelAstNodes.push(t.expressionStatement(
         t.assignmentExpression(
@@ -62,13 +62,13 @@ export default function parseDocument(document, documentId, parentScope, enumId 
         const variables = [];
 
         node.variableDefinitions.forEach((variable) => {
-          variables.push(parseVariable(variable, enumId, variableId));
+          variables.push(parseVariable(variable, clientId));
         });
 
         args.push(t.arrayExpression(variables));
       }
 
-      args.push(t.arrowFunctionExpression([t.identifier('root')], t.blockStatement(getSelections(node.selectionSet, parentSelections, spreadsId, enumId, variableId))));
+      args.push(t.arrowFunctionExpression([t.identifier('root')], t.blockStatement(getSelections(node.selectionSet, parentSelections, spreadsId, clientId))));
 
       let operationId;
 

--- a/src/parse-variable.js
+++ b/src/parse-variable.js
@@ -7,12 +7,18 @@ function extractVariableType(variable) {
 
 // Parses a GraphQL AST variable and returns the babel type for the variable in query builder syntax
 // variable('first', 'Int!')
-export default function parseVariable(variable, enumId = t.identifier('_enum'), variableId = t.identifier('variable')) {
+export default function parseVariable(variable, clientId = t.identifier('client')) {
   const args = [t.stringLiteral(variable.variable.name.value), t.stringLiteral(extractVariableType(variable))];
 
   if (variable.defaultValue) {
-    args.push(parseArgValue(variable.defaultValue, enumId));
+    args.push(parseArgValue(variable.defaultValue, clientId));
   }
 
-  return (t.callExpression(variableId, args));
+  return t.callExpression(
+    t.memberExpression(
+      clientId,
+      t.identifier('variable')
+    ),
+    args
+  );
 }

--- a/test/parse-arg-test.js
+++ b/test/parse-arg-test.js
@@ -12,7 +12,10 @@ suite('parse-arg-test', () => {
   test('it can parse enum args', () => {
     const arg = {name: {value: 'sortKey'}, value: {kind: 'EnumValue', value: 'TITLE'}};
 
-    assert.deepEqual(parseArg(arg), t.objectProperty(t.identifier('sortKey'), t.callExpression(t.identifier('_enum'), [t.stringLiteral('TITLE')])));
+    assert.deepEqual(parseArg(arg), t.objectProperty(
+      t.identifier('sortKey'),
+      t.callExpression(t.memberExpression(t.identifier('client'), t.identifier('enum')), [t.stringLiteral('TITLE')])
+    ));
   });
 
   test('it can parse object args', () => {
@@ -24,6 +27,9 @@ suite('parse-arg-test', () => {
   test('it can parse variable args', () => {
     const arg = {name: {value: 'input'}, value: {name: {value: 'inputVariable'}}};
 
-    assert.deepEqual(parseArg(arg), t.objectProperty(t.identifier('input'), t.callExpression(t.identifier('variable'), [t.stringLiteral('inputVariable')])));
+    assert.deepEqual(parseArg(arg), t.objectProperty(t.identifier('input'), t.callExpression(
+      t.memberExpression(t.identifier('client'), t.identifier('variable')),
+      [t.stringLiteral('inputVariable')])
+    ));
   });
 });

--- a/test/parse-arg-value-test.js
+++ b/test/parse-arg-value-test.js
@@ -19,7 +19,7 @@ suite('parse-arg-value-test', () => {
   test('it can parse enum arg values', () => {
     const argValue = parseValue('TITLE');
 
-    assert.deepEqual(parseArgValue(argValue), t.callExpression(t.identifier('_enum'), [t.stringLiteral('TITLE')]));
+    assert.deepEqual(parseArgValue(argValue), t.callExpression(t.memberExpression(t.identifier('client'), t.identifier('enum')), [t.stringLiteral('TITLE')]));
   });
 
   test('it can parse float arg values', () => {

--- a/test/parse-document-test.js
+++ b/test/parse-document-test.js
@@ -198,7 +198,10 @@ suite('parse-document-test', () => {
         ),
         [
           t.arrayExpression([
-            t.callExpression(t.identifier('variable'), [t.stringLiteral('id'), t.stringLiteral('ID')])
+            t.callExpression(
+              t.memberExpression(t.identifier('client'), t.identifier('variable')),
+              [t.stringLiteral('id'), t.stringLiteral('ID')]
+            )
           ]),
           t.arrowFunctionExpression(
             [t.identifier('root')],
@@ -217,7 +220,10 @@ suite('parse-document-test', () => {
                         t.objectExpression([
                           t.objectProperty(
                             t.identifier('id'),
-                            t.callExpression(t.identifier('variable'), [t.stringLiteral('id')])
+                            t.callExpression(
+                              t.memberExpression(t.identifier('client'), t.identifier('variable')),
+                              [t.stringLiteral('id')]
+                            )
                           )
                         ])
                       )

--- a/test/parse-variable-test.js
+++ b/test/parse-variable-test.js
@@ -5,21 +5,30 @@ import parseVariable from '../src/parse-variable';
 suite('parse-variable-test', () => {
   test('it can parse a simple variable into a Babel AST node', () => {
     const variable = {variable: {name: {value: 'first'}}, type: {kind: 'NamedType', name: {value: 'Int'}}};
-    const babelAstNode = t.callExpression(t.identifier('variable'), [t.stringLiteral('first'), t.stringLiteral('Int')]);
+    const babelAstNode = t.callExpression(
+      t.memberExpression(t.identifier('client'), t.identifier('variable')),
+      [t.stringLiteral('first'), t.stringLiteral('Int')]
+    );
 
     assert.deepEqual(parseVariable(variable), babelAstNode);
   });
 
   test('it can parse a non-null variable into a Babel AST node', () => {
     const variable = {variable: {name: {value: 'first'}}, type: {kind: 'NonNullType', type: {name: {value: 'Int'}}}};
-    const babelAstNode = t.callExpression(t.identifier('variable'), [t.stringLiteral('first'), t.stringLiteral('Int!')]);
+    const babelAstNode = t.callExpression(
+      t.memberExpression(t.identifier('client'), t.identifier('variable')),
+      [t.stringLiteral('first'), t.stringLiteral('Int!')]
+    );
 
     assert.deepEqual(parseVariable(variable), babelAstNode);
   });
 
   test('it can parse a variables with a default value into a Babel AST node', () => {
     const variable = {variable: {name: {value: 'first'}}, type: {kind: 'NamedType', name: {value: 'Int'}}, defaultValue: {kind: 'IntValue', value: 3}};
-    const babelAstNode = t.callExpression(t.identifier('variable'), [t.stringLiteral('first'), t.stringLiteral('Int'), t.numericLiteral(3)]);
+    const babelAstNode = t.callExpression(
+      t.memberExpression(t.identifier('client'), t.identifier('variable')),
+      [t.stringLiteral('first'), t.stringLiteral('Int'), t.numericLiteral(3)]
+    );
 
     assert.deepEqual(parseVariable(variable), babelAstNode);
   });


### PR DESCRIPTION
This PR allows the user to specify the name of the `client` variable. 

### Usage
```js
gql(myClient)`query ($first: Int!) {
  shop {
    products(first: $first, sortKey: TITLE) {
      ...
    }
  }
}`
```
transforms to
```js 
const _document = myClient.document();

_document.addQuery([myClient.variable("first", "Int!")], root => {
  root.add("shop", shop => {
    shop.add("products", {args: {sortKey: myClient.enum("TITLE"), first: myClient.variable("first")}}, products => {
      ...
    });
  });
})
```

The user can choose to use the default client variable name (`client`) and tag only with `gql` like so:
```js
gql`query {
  ...
}`
```