### PR TITLE
[FIX] Tag checking

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -40,7 +40,7 @@ export default function() {
       TaggedTemplateExpression(path, state) {
         const tag = state.opts.tag || 'gql';
 
-        if (path.node.tag.callee.name === tag) {
+        if (path.node.tag.callee && path.node.tag.callee.name === tag) {
           path.traverse(templateElementVisitor, {parentPath: path, clientId: path.node.tag.arguments[0]});
         }
       }

--- a/test/tag-test.js
+++ b/test/tag-test.js
@@ -9,7 +9,7 @@ suite('plugin-test', () => {
   }
 
   test('it can transform queries with the gql tag', () => {
-    const result = transform('gql(client)`{shop{name}}`;', {plugins: ['.']});
+    const result = transform('gql(client)`{shop{name}}`;', {plugins: ['./src/index.js']});
 
     assert.deepEqual(tokens(result.code), tokens(`
       const _document = client.document();
@@ -25,7 +25,7 @@ suite('plugin-test', () => {
   });
 
   test('it can transform queries with the gql tag nested in functions', () => {
-    const result = transform('function foo() { gql(client)`{shop{name}}`; }', {plugins: ['.']});
+    const result = transform('function foo() { gql(client)`{shop{name}}`; }', {plugins: ['./src/index.js']});
 
     assert.deepEqual(tokens(result.code), tokens(`
       function foo() {
@@ -43,7 +43,7 @@ suite('plugin-test', () => {
   });
 
   test('it can transform queries with a custom tag', () => {
-    const result = transform('cat(client)`{shop{name}}`;', {plugins: [['.', {tag: 'cat'}]]});
+    const result = transform('cat(client)`{shop{name}}`;', {plugins: [['./src/index.js', {tag: 'cat'}]]});
 
     assert.deepEqual(tokens(result.code), tokens(`
       const _document = client.document();
@@ -56,5 +56,13 @@ suite('plugin-test', () => {
 
       _document;`)
     );
+  });
+
+  test('it does nothing to other tagged expressions', () => {
+    const result = transform('tag`console.log("hello!")`;', {plugins: ['./src/index.js']});
+    const resultWithArguments = transform('tag(arg)`console.log("hello!")`;', {plugins: ['./src/index.js']});
+
+    assert.deepEqual(tokens(result.code), tokens('tag`console.log("hello!")`;'));
+    assert.deepEqual(tokens(resultWithArguments.code), tokens('tag(arg)`console.log("hello!")`;'));
   });
 });


### PR DESCRIPTION
If a tag doesn't have arguments, it doesn't have a `callee` field, so something like
```js
tag`
  // stuff
`
``` 
would error out from trying to get `callee.name`. This PR adds a check to make sure this plugin doesn't affect non-gql tags. Also changes the path to the plugin in tests to use the src code.