### PR TITLE
[FIX] Properly parse array values

### DIFF
--- a/src/parse-arg-value.js
+++ b/src/parse-arg-value.js
@@ -1,23 +1,24 @@
 import * as t from 'babel-types';
 
 export default function parseArgValue(argValue, clientId = t.identifier('client')) {
-  if (argValue.kind === 'StringValue') {
-    return t.stringLiteral(argValue.value);
-  } else if (argValue.kind === 'EnumValue') {
-    return t.callExpression(
-      t.memberExpression(
-        clientId,
-        t.identifier('enum')
-      ),
-      [t.stringLiteral(argValue.value)]
-    );
-  } else if (argValue.kind === 'IntValue') {
-    return t.numericLiteral(parseInt(argValue.value, 10));
-  } else if (argValue.kind === 'FloatValue') {
-    return t.numericLiteral(parseFloat(argValue.value));
-  } else if (argValue.kind === 'BooleanValue') {
-    return t.booleanLiteral(argValue.value);
-  } else {
-    throw Error(`Unrecognized type "${argValue.kind}"`);
+  switch (argValue.kind) {
+    case 'StringValue':
+      return t.stringLiteral(argValue.value);
+    case 'EnumValue':
+      return t.callExpression(
+        t.memberExpression(
+          clientId,
+          t.identifier('enum')
+        ),
+        [t.stringLiteral(argValue.value)]
+      );
+    case 'IntValue':
+      return t.numericLiteral(parseInt(argValue.value, 10));
+    case 'FloatValue':
+      return t.numericLiteral(parseFloat(argValue.value));
+    case 'BooleanValue':
+      return t.booleanLiteral(argValue.value);
+    default:
+      throw Error(`Unrecognized type "${argValue.kind}"`);
   }
 }

--- a/src/parse-variable.js
+++ b/src/parse-variable.js
@@ -2,13 +2,22 @@ import * as t from 'babel-types';
 import parseArgValue from './parse-arg-value';
 
 function extractVariableType(variable) {
-  return variable.type.kind === 'NonNullType' ? `${variable.type.type.name.value}!` : variable.type.name.value;
+  if (variable.kind === 'NonNullType') {
+    return `${extractVariableType(variable.type)}!`;
+  }
+
+  if (variable.kind === 'ListType') {
+    return `[${extractVariableType(variable.type)}]`;
+  }
+
+  // NamedType
+  return variable.name.value;
 }
 
 // Parses a GraphQL AST variable and returns the babel type for the variable in query builder syntax
 // variable('first', 'Int!')
 export default function parseVariable(variable, clientId = t.identifier('client')) {
-  const args = [t.stringLiteral(variable.variable.name.value), t.stringLiteral(extractVariableType(variable))];
+  const args = [t.stringLiteral(variable.variable.name.value), t.stringLiteral(extractVariableType(variable.type))];
 
   if (variable.defaultValue) {
     args.push(parseArgValue(variable.defaultValue, clientId));

--- a/src/parse-variable.js
+++ b/src/parse-variable.js
@@ -2,16 +2,15 @@ import * as t from 'babel-types';
 import parseArgValue from './parse-arg-value';
 
 function extractVariableType(variable) {
-  if (variable.kind === 'NonNullType') {
-    return `${extractVariableType(variable.type)}!`;
+  switch (variable.kind) {
+    case 'NonNullType':
+      return `${extractVariableType(variable.type)}!`;
+    case 'ListType':
+      return `[${extractVariableType(variable.type)}]`;
+    default:
+      // NamedType
+      return variable.name.value;
   }
-
-  if (variable.kind === 'ListType') {
-    return `[${extractVariableType(variable.type)}]`;
-  }
-
-  // NamedType
-  return variable.name.value;
 }
 
 // Parses a GraphQL AST variable and returns the babel type for the variable in query builder syntax

--- a/test/parse-variable-test.js
+++ b/test/parse-variable-test.js
@@ -32,5 +32,125 @@ suite('parse-variable-test', () => {
 
     assert.deepEqual(parseVariable(variable), babelAstNode);
   });
+
+  test('it can parse variables with array values into a Babel AST node', () => {
+    const variable = {
+      variable: {
+        name: {
+          value: 'arrayValue'
+        }
+      },
+      type: {
+        kind: 'ListType',
+        type: {
+          kind: 'NamedType',
+          name: {
+            kind: 'Name',
+            value: 'CheckoutLineItemUpdateInput'
+          }
+        }
+      }
+    };
+
+    const babelAstNode = t.callExpression(
+      t.memberExpression(t.identifier('client'), t.identifier('variable')),
+      [t.stringLiteral('arrayValue'), t.stringLiteral('[CheckoutLineItemUpdateInput]')]
+    );
+
+    assert.deepEqual(parseVariable(variable), babelAstNode);
+  });
+
+  test('it can parse variables with array values with non-null types into a Babel AST node', () => {
+    const variable = {
+      variable: {
+        name: {
+          value: 'arrayValue'
+        }
+      },
+      type: {
+        kind: 'ListType',
+        type: {
+          kind: 'NonNullType',
+          type: {
+            kind: 'NamedType',
+            name: {
+              kind: 'Name',
+              value: 'CheckoutLineItemUpdateInput'
+            }
+          }
+        }
+      }
+    };
+
+    const babelAstNode = t.callExpression(
+      t.memberExpression(t.identifier('client'), t.identifier('variable')),
+      [t.stringLiteral('arrayValue'), t.stringLiteral('[CheckoutLineItemUpdateInput!]')]
+    );
+
+    assert.deepEqual(parseVariable(variable), babelAstNode);
+  });
+
+  test('it can parse variables with non-null array values with non-null types into a Babel AST node', () => {
+    const variable = {
+      variable: {
+        name: {
+          value: 'arrayValue'
+        }
+      },
+      type: {
+        kind: 'NonNullType',
+        type: {
+          kind: 'ListType',
+          type: {
+            kind: 'NonNullType',
+            type: {
+              kind: 'NamedType',
+              name: {
+                kind: 'Name',
+                value: 'CheckoutLineItemUpdateInput'
+              }
+            }
+          }
+        }
+      }
+    };
+
+    const babelAstNode = t.callExpression(
+      t.memberExpression(t.identifier('client'), t.identifier('variable')),
+      [t.stringLiteral('arrayValue'), t.stringLiteral('[CheckoutLineItemUpdateInput!]!')]
+    );
+
+    assert.deepEqual(parseVariable(variable), babelAstNode);
+  });
+
+  test('it can parse variables with non-null array values into a Babel AST node', () => {
+    const variable = {
+      variable: {
+        name: {
+          value: 'arrayValue'
+        }
+      },
+      type: {
+        kind: 'NonNullType',
+        type: {
+          kind: 'ListType',
+          type: {
+            kind: 'NamedType',
+            name: {
+              kind: 'Name',
+              value: 'CheckoutLineItemUpdateInput'
+            }
+          }
+        }
+      }
+    };
+
+    const babelAstNode = t.callExpression(
+      t.memberExpression(t.identifier('client'), t.identifier('variable')),
+      [t.stringLiteral('arrayValue'), t.stringLiteral('[CheckoutLineItemUpdateInput]!')]
+    );
+
+    assert.deepEqual(parseVariable(variable), babelAstNode);
+  });
 });
 


### PR DESCRIPTION
Variables with array values like `[CheckoutLineItemUpdateInput]` did not get parsed properly. This PR updates the `extractVariableType` method to work recursively to add `!` or `[]` to types that need them.