### PR TITLE
Export gql tag

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,31 +23,43 @@ $ yarn add babel-plugin-graphql-js-client-transform
 }
 ```
 
-By default, the plugin will search for the tag `gql`. This value is configurable by passing in a `tag` option to the plugin.
-
-```
-{
-  "plugins": [
-    ["graphql-js-client-transform", {"tag": "customTag"}]
-  ]
-}
-```
-
 ## Usage
 
-Simply tag your raw GraphQL queries and the plugin will transform them. An instance of
-[Shopify/graphql-js-client](https://github.com/Shopify/graphql-js-client)
+```js
+// Finds template literals tagged with gql
+import {gql} from 'babel-plugin-graphql-js-client-transform';
+
+// Finds template literals tagged with customTagName
+import {gql as customTagName} from 'babel-plugin-graphql-js-client-transform';
+```
+The plugin will pick up any template literals tagged with the imported `gql` function.
+Do not reassign the function to another variable after it has been imported.
+```js
+import {gql} from 'babel-plugin-graphql-js-client-transform';
+
+...
+
+const newTag = gql;
+
+newTag(client)`...`; // Don't do this. This template literal won't be transformed.
+```
+
+An instance of [Shopify/graphql-js-client](https://github.com/Shopify/graphql-js-client)
 must be supplied to the tag.
 
 ## Examples
 
-The following are example usages with the default variable name.
+The following are example usages.
 
 #### Example 1
 Convert a simple query.
 
 ##### Source Code
 ``` js
+import {gql} from 'babel-plugin-graphql-js-client-transform';
+
+...
+
 client.send(gql(client)`
   query {
     shop {
@@ -59,6 +71,10 @@ client.send(gql(client)`
 
 ##### Transformed Code
 ```js
+import {gql} from 'babel-plugin-graphql-js-client-transform';
+
+...
+
 const _document = client.document(); // Creates a document to store the query
 _document.addQuery((root) => {
   root.add('shop', (shop) => {
@@ -75,6 +91,10 @@ The query can also be stored inside a variable instead of being sent directly.
 ##### Source Code
 
 ```js
+import {gql} from 'babel-plugin-graphql-js-client-transform';
+
+...
+
 const query = gql(client)`
   query {
     shop {
@@ -88,6 +108,10 @@ client.send(query);
 
 ##### Transformed Code
 ```js
+import {gql} from 'babel-plugin-graphql-js-client-transform';
+
+...
+
 const _document = client.document(); // Creates a document to store the query
 _document.addQuery((root) => {
   root.add('shop', (shop) => {

--- a/src/index.js
+++ b/src/index.js
@@ -56,8 +56,10 @@ export default function() {
 
 /**
  * This function should not be invoked.
- * This function is used to tag raw GraphQL queries that will be transcompiled into graphql-js-client's query builder syntax.
+ * This function is used to tag raw GraphQL queries that will be
+ * transcompiled into graphql-js-client's query builder syntax.
  */
 export function gql() {
-  throw new Error('This function should not be invoked. It should be used to tag template literals that will be transcompiled into graphql-js-client\'s query builder syntax.');
+  throw new Error(`This function should not be invoked. It should be used to tag template literals that will be
+    transcompiled into graphql-js-client's query builder syntax.`);
 }

--- a/src/index.js
+++ b/src/index.js
@@ -37,13 +37,27 @@ const templateElementVisitor = {
 export default function() {
   return {
     visitor: {
-      TaggedTemplateExpression(path, state) {
-        const tag = state.opts.tag || 'gql';
+      ImportSpecifier(path, state) {
+        // Find the gql import
+        if (path.node.imported.name === 'gql') {
+          // Save the name of the import
+          state.tag = path.node.local.name;
+        }
+      },
 
-        if (path.node.tag.callee && path.node.tag.callee.name === tag) {
+      TaggedTemplateExpression(path, state) {
+        if (path.node.tag.callee && path.node.tag.callee.name === state.tag) {
           path.traverse(templateElementVisitor, {parentPath: path, clientId: path.node.tag.arguments[0]});
         }
       }
     }
   };
+}
+
+/**
+ * This function should not be invoked.
+ * This function is used to tag raw GraphQL queries that will be transcompiled into graphql-js-client's query builder syntax.
+ */
+export function gql() {
+  throw new Error('This function should not be invoked. It should be used to tag template literals that will be transcompiled into graphql-js-client\'s query builder syntax.');
 }

--- a/test/tag-test.js
+++ b/test/tag-test.js
@@ -8,15 +8,35 @@ suite('plugin-test', () => {
     return code.split(splitter).filter((token) => Boolean(token));
   }
 
-  test('it can transform queries with the gql tag', () => {
-    const result = transform('gql(client)`{shop{name}}`;', {plugins: ['./src/index.js']});
+  test('it can transform queries tagged with the imported gql function', () => {
+    const result = transform("import {gql} from './src/index';\ngql(client)`{shop{name}}`;", {plugins: ['./src/index.js']});
 
     assert.deepEqual(tokens(result.code), tokens(`
+      import { gql } from './src/index';
+
       const _document = client.document();
 
       _document.addQuery(root => {
-        root.add("shop", shop => {
-          shop.add("name");
+        root.add('shop', shop => {
+          shop.add('name');
+        });
+      })
+
+      _document;`)
+    );
+  });
+
+  test('it can transform queries tagged with the gql function imported as another name', () => {
+    const result = transform("import {gql as tag} from './src/index';\ntag(client)`{shop{name}}`;", {plugins: ['./src/index.js']});
+
+    assert.deepEqual(tokens(result.code), tokens(`
+      import { gql as tag } from './src/index';
+
+      const _document = client.document();
+
+      _document.addQuery(root => {
+        root.add('shop', shop => {
+          shop.add('name');
         });
       })
 
@@ -25,36 +45,22 @@ suite('plugin-test', () => {
   });
 
   test('it can transform queries with the gql tag nested in functions', () => {
-    const result = transform('function foo() { gql(client)`{shop{name}}`; }', {plugins: ['./src/index.js']});
+    const result = transform("import {gql} from './src/index';\nfunction foo() { gql(client)`{shop{name}}`; }", {plugins: ['./src/index.js']});
 
     assert.deepEqual(tokens(result.code), tokens(`
+      import { gql } from './src/index';
+
       function foo() {
         const _document = client.document();
 
         _document.addQuery(root => {
-          root.add("shop", shop => {
-            shop.add("name");
+          root.add('shop', shop => {
+            shop.add('name');
           });
         })
 
         _document;
       }`)
-    );
-  });
-
-  test('it can transform queries with a custom tag', () => {
-    const result = transform('cat(client)`{shop{name}}`;', {plugins: [['./src/index.js', {tag: 'cat'}]]});
-
-    assert.deepEqual(tokens(result.code), tokens(`
-      const _document = client.document();
-
-      _document.addQuery(root => {
-        root.add("shop", shop => {
-          shop.add("name");
-        });
-      })
-
-      _document;`)
     );
   });
 

--- a/test/tag-test.js
+++ b/test/tag-test.js
@@ -1,7 +1,7 @@
 import assert from 'assert';
 import {transform} from 'babel-core';
 
-suite('plugin-test', () => {
+suite('tag-test', () => {
   const splitter = /[\s]+/;
 
   function tokens(code) {


### PR DESCRIPTION
- Adds another visitor to visit named imports and find what `gql` is imported as.
- Removes the ability to specify a custom tag through `options` in `.babelrc` since the user could just do `import {gql as x} from 'babel-plugin-graphql-js-client-transform';`.

